### PR TITLE
Fix ABAP Strust issue 17

### DIFF
--- a/src/#apmg#cl_strust.clas.abap
+++ b/src/#apmg#cl_strust.clas.abap
@@ -129,6 +129,10 @@ CLASS /apmg/cl_strust DEFINITION
       RAISING
         /apmg/cx_error.
 
+    METHODS get_logs
+      RETURNING
+        VALUE(result) TYPE STANDARD TABLE OF /apmg/strust_log WITH DEFAULT KEY.
+
   PROTECTED SECTION.
   PRIVATE SECTION.
 
@@ -593,6 +597,13 @@ CLASS /apmg/cl_strust IMPLEMENTATION.
     _log_save( comment ).
 
     result = certs_new.
+
+  ENDMETHOD.
+
+
+  METHOD get_logs.
+
+    result = logs.
 
   ENDMETHOD.
 

--- a/src/#apmg#strust_updater.prog.abap
+++ b/src/#apmg#strust_updater.prog.abap
@@ -241,6 +241,30 @@ START-OF-SELECTION.
         remove_expired = p_remove ).
 
       WRITE / 'Certificates saved' COLOR COL_POSITIVE.
+
+      IF p_remove = abap_true.
+        DATA(logs) TYPE STANDARD TABLE OF /apmg/strust_log WITH DEFAULT KEY.
+        logs = strust->get_logs( ).
+
+        DATA(removed_count) = 0.
+
+        LOOP AT logs ASSIGNING FIELD-SYMBOL(<log>) WHERE message = 'Removed'.
+          IF removed_count = 0.
+            SKIP.
+            WRITE / 'Certificates removed:' COLOR COL_TOTAL.
+          ENDIF.
+          removed_count += 1.
+          WRITE: /5 <log>-cert_subject,
+            AT 130 |{ <log>-date_from DATE = ISO }|,
+            AT 145 |{ <log>-date_to DATE = ISO }|,
+            AT 158 ''.
+        ENDLOOP.
+
+        IF removed_count = 0.
+          SKIP.
+          WRITE / 'No expired certificates were removed' COLOR COL_TOTAL.
+        ENDIF.
+      ENDIF.
     CATCH /apmg/cx_error INTO error.
       WRITE: / 'Error updating certificate:' COLOR COL_NEGATIVE, error->get_text( ).
   ENDTRY.


### PR DESCRIPTION
Display removed certificates in the updater report to address issue #17.

---
<a href="https://cursor.com/background-agent?bcId=bc-9176d8b0-2b12-4a08-a1ae-621a85a1f988">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9176d8b0-2b12-4a08-a1ae-621a85a1f988">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

